### PR TITLE
Ends test cases immediately after failure

### DIFF
--- a/Tests/TypeSafeKituraClientTests/MainTests.swift
+++ b/Tests/TypeSafeKituraClientTests/MainTests.swift
@@ -54,6 +54,8 @@ class MainTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        continueAfterFailure = false
+
         Kitura.addHTTPServer(onPort: 8080, with: controller.router)
         Kitura.start()
 


### PR DESCRIPTION
Overrides the default `continueAfterFailure` XCTest parameter.

This prevents waiting unnecessarily for failed XCTestExpectation enabling faster test feedback.