### PR TITLE
feat: support POST requests returning Id via Location

### DIFF
--- a/Sources/KituraKit/Client.swift
+++ b/Sources/KituraKit/Client.swift
@@ -168,7 +168,7 @@ public class KituraKit {
     /// ### Usage Example: ###
     /// ````
     /// let client = KituraKit.default
-    /// client.post("/", data: dataToSend) { (id: Id? returnedItem: O?, error: Error?) -> Void in
+    /// client.post("/", data: dataToSend) { (id: Id?, returnedItem: O?, error: Error?) -> Void in
     ///     print("\(id): \(returnedItem)")
     /// }
     /// ````

--- a/Tests/KituraKitTests/Controller.swift
+++ b/Tests/KituraKitTests/Controller.swift
@@ -60,6 +60,16 @@ public class Controller {
             self.userStore[String(user.id)] = user
             respondWith(user, nil)
         }
+        
+        router.post("/usersid") { (user: User?, respondWith: (Int?, User?, RequestError?) -> Void) in
+            guard let user = user else {
+                respondWith(nil, nil, .badRequest)
+                return
+            }
+            self.userStore[String(user.id)] = user
+            respondWith(user.id, user, nil)
+        }
+        
         router.put("/users") { (id: Int, user: User?, respondWith: (User?, RequestError?) -> Void) in
             self.userStore[String(id)] = user
             respondWith(user, nil)

--- a/Tests/KituraKitTests/MainTests.swift
+++ b/Tests/KituraKitTests/MainTests.swift
@@ -36,6 +36,7 @@ class MainTests: XCTestCase {
             ("testClientGetSingle", testClientGetSingle),
             ("testClientGetSingleErrorPath", testClientGetSingleErrorPath),
             ("testClientPost", testClientPost),
+            ("testClientPostWithIdentifier", testClientPostWithIdentifier),
             ("testClientPostErrorPath", testClientPostErrorPath),
             ("testClientPut", testClientPut),
             ("testClientPutErrorPath", testClientPutErrorPath),
@@ -144,6 +145,30 @@ class MainTests: XCTestCase {
             }
 
             XCTAssertEqual(user, newUser)
+            expectation1.fulfill()
+        }
+        waitForExpectations(timeout: 3.0, handler: nil)
+    }
+    
+    func testClientPostWithIdentifier() {
+        let expectation1 = expectation(description: "A response is received from the server -> user")
+        
+        // Invoke POST operation on library
+        let userId = 5
+        let newUser = User(id: userId, name: "John Doe")
+        
+        client.post("/usersid", data: newUser) { (id: Int?, user: User?, error: RequestError?) -> Void in
+            guard let user = user else {
+                XCTFail("Failed to post user! Error: \(String(describing: error))")
+                return
+            }
+            guard let id = id else {
+                XCTFail("Failed to receive Identifier back from post")
+                return
+            }
+            
+            XCTAssertEqual(user, newUser)
+            XCTAssertEqual(userId, id)
             expectation1.fulfill()
         }
         waitForExpectations(timeout: 3.0, handler: nil)


### PR DESCRIPTION
This is a pair to PR#1166 in the Kitura repo that allows a developer to respond to a POST request with an Identifier as well as the created type. The Identifier is then encoded into the Location header.

This adds the client version that allows you to specify a response handler that additionally returns an Identifier, and this hoists the store value out of the Location header.

Do not merge until the equivalent Kitura PR is merged!