### PR TITLE
Add non-array get support, update doc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", .upToNextMinor(from: "0.0.6")),
-        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .upToNextMinor(from: "0.0.14")),
+        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .upToNextMinor(from: "0.0.15")),
         // Kitura is only needed for testing (test dependency :-/)
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/KituraKitTests/Controller.swift
+++ b/Tests/KituraKitTests/Controller.swift
@@ -43,7 +43,7 @@ public class Controller {
             let users = self.userStore.map({ $0.value })
             respondWith(users, nil)
         }
-        
+
         router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
             guard let user = self.userStore[id.value] else {
                 respondWith(nil, .notFound)
@@ -51,7 +51,7 @@ public class Controller {
             }
             respondWith(user, nil)
         }
-        
+
         router.post("/users") { (user: User?, respondWith: (User?, RequestError?) -> Void) in
             guard let user = user else {
                 respondWith(nil, .badRequest)
@@ -60,7 +60,7 @@ public class Controller {
             self.userStore[String(user.id)] = user
             respondWith(user, nil)
         }
-        
+
         router.post("/usersid") { (user: User?, respondWith: (Int?, User?, RequestError?) -> Void) in
             guard let user = user else {
                 respondWith(nil, nil, .badRequest)
@@ -69,7 +69,7 @@ public class Controller {
             self.userStore[String(user.id)] = user
             respondWith(user.id, user, nil)
         }
-        
+
         router.put("/users") { (id: Int, user: User?, respondWith: (User?, RequestError?) -> Void) in
             self.userStore[String(id)] = user
             respondWith(user, nil)
@@ -87,7 +87,7 @@ public class Controller {
                 respondWith(exisitingUser, nil)
             }
         }
-        
+
         router.delete("/users") { (id: Int, respondWith: (RequestError?) -> Void) in
             guard let _ = self.userStore.removeValue(forKey: id.value) else {
                 respondWith(.notFound)
@@ -95,7 +95,7 @@ public class Controller {
             }
             respondWith(nil)
         }
-        
+
         router.delete("/users") { (respondWith: (RequestError?) -> Void) in
             self.userStore.removeAll()
             respondWith(nil)
@@ -108,6 +108,10 @@ public class Controller {
         router.patch("/employees/:id", handler: updateEmployee)
         router.delete("/employees/:id", handler: deleteEmployee)
         router.delete("/employees", handler: deleteAllEmployees)
+        // health route
+        router.get("/health") { (respondWith: (Status?, RequestError?) -> Void) in
+            respondWith(Status("GOOD"), nil)
+        }
     }
 
 
@@ -134,7 +138,7 @@ public class Controller {
         let employees = employeeStore.map { $1 }
         try response.status(.OK).send(data: encoder.encode(employees)).end()
     }
-    
+
     public func getEmployee(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         defer {
             next()
@@ -143,17 +147,17 @@ public class Controller {
             response.status(.badRequest)
             return
         }
-        
+
         //print("employeeStore - \(employeeStore)")
-        
+
         guard let employee = employeeStore[id] else {
             response.status(.badRequest)
             return
         }
-        
+
         try response.status(.OK).send(data: encoder.encode(employee))
     }
-    
+
     public func addEmployee(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         defer {
             next()
@@ -162,9 +166,9 @@ public class Controller {
             var data = Data()
             _ = try request.read(into: &data)
             let employee = try decoder.decode(Employee.self, from: data)
-            
+
             let employees = employeeStore.map({ $0.value })
-            
+
             for current in employees {
                 if current == employee {
                     response.status(.conflict)
@@ -172,13 +176,13 @@ public class Controller {
                 }
             }
             employeeStore[String(employee.id)] = employee
-            
+
             response.status(.OK).send(data: data)
         } catch {
             response.status(.unprocessableEntity)
         }
     }
-    
+
     public func updateEmployee(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         defer {
             next()
@@ -197,12 +201,12 @@ public class Controller {
             response.status(.unprocessableEntity)
         }
     }
-    
+
     public func deleteAllEmployees(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         employeeStore = [:]
         try response.status(.OK).end()
     }
-    
+
     public func deleteEmployee(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
         defer {
             next()
@@ -211,11 +215,11 @@ public class Controller {
             response.status(.badRequest)
             return
         }
-        
+
         guard let _ = employeeStore[id] else {
             response.status(.notFound)
             return
-        }        
+        }
         employeeStore.removeValue(forKey: id)
         response.status(.OK)
     }

--- a/Tests/KituraKitTests/MainTests.swift
+++ b/Tests/KituraKitTests/MainTests.swift
@@ -33,6 +33,7 @@ class MainTests: XCTestCase {
         return [
             ("testClientGet", testClientGet),
             ("testClientGetErrorPath", testClientGetErrorPath),
+            ("testClientGetSingleNoId", testClientGetSingleNoId),
             ("testClientGetSingle", testClientGetSingle),
             ("testClientGetSingleErrorPath", testClientGetSingleErrorPath),
             ("testClientPost", testClientPost),
@@ -96,6 +97,21 @@ class MainTests: XCTestCase {
                 XCTFail("Failed to get expected error from server: \(String(describing: error))")
                 return
             }
+        }
+        waitForExpectations(timeout: 3.0, handler: nil)
+    }
+
+    func testClientGetSingleNoId() {
+        let expectation1 = expectation(description: "A response is received from the server -> user")
+
+        // Invoke GET operation on library
+        client.get("/health") { (status: Status?, error: RequestError?) -> Void in
+            guard let status = status else {
+                XCTFail("Failed to get status! Error: \(String(describing: error))")
+                return
+            }
+            XCTAssertEqual(status.description, "GOOD")
+            expectation1.fulfill()
         }
         waitForExpectations(timeout: 3.0, handler: nil)
     }

--- a/Tests/KituraKitTests/Models.swift
+++ b/Tests/KituraKitTests/Models.swift
@@ -38,11 +38,11 @@ public struct UserOptional: Codable, Equatable {
         self.id = id
         self.name = name
     }
-    
+
     public static func ==(lhs: UserOptional, rhs: UserOptional) -> Bool {
         return (lhs.id == rhs.id) && (lhs.name == rhs.name)
     }
-    
+
 }
 
 public struct Employee: Codable, Equatable {    
@@ -67,3 +67,10 @@ let initialStoreEmployee = [
     "3": Employee(id: "3", name: "Ricardo"),
     "4": Employee(id: "4", name: "Aaron")
 ]
+
+public struct Status: Codable {
+    let description: String
+    init(_ desc: String) {
+        description = desc
+    }
+}


### PR DESCRIPTION
This PR adds support for calling get on a route without providing an ID and getting a non-array Codable returned. This is the client counterpart to PR https://github.com/IBM-Swift/Kitura/pull/1176 and is also dependent on https://github.com/IBM-Swift/KituraContracts/pull/4.