### PR TITLE
Add codable query to pod branch

### DIFF
--- a/ci/update.sh
+++ b/ci/update.sh
@@ -66,6 +66,7 @@ cp -r Sources/CircuitBreaker ../../../Sources/KituraKit
 
 cd ../KituraContracts*
 cp -r  Sources/KituraContracts ../../../Sources/KituraKit
+mv ../../../Sources/KituraKit/CodableQuery/*.swift ../
 
 cd ../SwiftyRequest*
 cp -r Sources/SwiftyRequest ../../../Sources/KituraKit
@@ -82,9 +83,14 @@ sed -i '/import KituraContracts/d' RequestErrorExtension.swift
 sed -i '/import SwiftyRequest/d' RequestErrorExtension.swift
 cd SwiftyRequest/
 sed -i '/import CircuitBreaker/d' RestRequest.swift
+sed -i '/import LoggerAPI/d' RestRequest.swift
 cd ../CircuitBreaker
 sed -i '/import LoggerAPI/d' CircuitBreaker.swift
 sed -i '/import LoggerAPI/d' Stats.swift
+cd ../KituraContracts
+sed -i '/import LoggerAPI/d' Extensions.swift
+sed -i '/import LoggerAPI/d' QueryEncoder.swift
+sed -i '/import LoggerAPI/d' QueryDecoder.swift
 
 cd ../../../
 

--- a/ci/update.sh
+++ b/ci/update.sh
@@ -66,7 +66,7 @@ cp -r Sources/CircuitBreaker ../../../Sources/KituraKit
 
 cd ../KituraContracts*
 cp -r  Sources/KituraContracts ../../../Sources/KituraKit
-mv ../../../Sources/KituraKit/CodableQuery/*.swift ../
+mv ../../../Sources/KituraKit/KituraContracts/CodableQuery/*.swift ../../../Sources/KituraKit/KituraContracts/
 
 cd ../SwiftyRequest*
 cp -r Sources/SwiftyRequest ../../../Sources/KituraKit


### PR DESCRIPTION
A CodableQuery directory was added to KituraContracts, this wasn't being picked up by the pod branch. As well as that various import statements needed to be removed. 