### PR TITLE
Remove old directories before copy

### DIFF
--- a/ci/update.sh
+++ b/ci/update.sh
@@ -59,16 +59,20 @@ git pull origin master
 swift package resolve
 
 cd .build/checkouts/LoggerAPI*
+rm -rf ../../../Sources/KituraKit/LoggerAPI
 cp -r Sources/LoggerAPI ../../../Sources/KituraKit
 
 cd ../CircuitBreaker*
+rm -rf ../../../Sources/KituraKit/CircuitBreaker
 cp -r Sources/CircuitBreaker ../../../Sources/KituraKit
 
 cd ../KituraContracts*
+rm -rf ../../../Sources/KituraKit/KituraContracts
 cp -r  Sources/KituraContracts ../../../Sources/KituraKit
 mv ../../../Sources/KituraKit/KituraContracts/CodableQuery/*.swift ../../../Sources/KituraKit/KituraContracts/
 
 cd ../SwiftyRequest*
+rm -rf ../../../Sources/KituraKit/SwiftyRequest
 cp -r Sources/SwiftyRequest ../../../Sources/KituraKit
 
 cd ../../../Sources/KituraKit


### PR DESCRIPTION
This PR is to ensure we clear out all of the old source code on the `pod` branch before we copy over the new code. 
This is to resolve an issue where a file name changed and the `update.sh` script treated it as a new file and copied it over causing an error when trying to use KituraKit in a project. 

