### PR TITLE
Update podspec to point at 0.0.23 release

### DIFF
--- a/KituraKit.podspec
+++ b/KituraKit.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name        = "KituraKit"
-  s.version     = "0.0.22"
+  s.version     = "0.0.23"
   s.summary     = "KituraKit is a library for making Codable HTTP Requests to a Kitura server"
   s.homepage    = "https://github.com/IBM-Swift/KituraKit"
   s.license     = { :type => "Apache License, Version 2.0" }


### PR DESCRIPTION
This pull request updates the podspec file to the 0.0.23 release for Cocoapods.