### PR TITLE
[WIP] Update Podspec to 1.0.0

### DIFF
--- a/KituraKit.podspec
+++ b/KituraKit.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name        = "KituraKit"
-  s.version     = "0.0.24"
+  s.version     = "1.0.0"
   s.summary     = "KituraKit is a library for making Codable HTTP Requests to a Kitura server"
   s.homepage    = "https://github.com/IBM-Swift/KituraKit"
   s.license     = { :type => "Apache License, Version 2.0" }
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/KituraKit.git", :tag => s.version }
   s.source_files = "Sources/**/*.swift"
-  s.dependency 'SwiftyRequest', '~> 2.0'
-  s.dependency 'KituraContracts', '~> 1.1'
+  s.dependency 'SwiftyRequest', '~> 3.0'
+  s.dependency 'KituraContracts', '~> 1.2'
 end


### PR DESCRIPTION
Update the Podspec for the 1.0.0 release, and update the SwiftyRequest dependency to 3.0.

DO NOT MERGE: Depends on SwiftyRequest 3.0 pod (https://github.com/IBM-Swift/SwiftyRequest/pull/76)